### PR TITLE
댓글 기능 구현

### DIFF
--- a/src/main/java/com/example/delibuddy/domain/comment/Comment.java
+++ b/src/main/java/com/example/delibuddy/domain/comment/Comment.java
@@ -46,4 +46,11 @@ public class Comment extends BaseTimeEntity {
     public void setAsIsDeleted(){
         isDeleted = Boolean.TRUE;
     }
+    public Boolean hasParent(){
+        return parent != null;
+    }
+    public void setParent(Comment parent){
+        this.parent = parent;
+    }
+
 }

--- a/src/main/java/com/example/delibuddy/domain/comment/Comment.java
+++ b/src/main/java/com/example/delibuddy/domain/comment/Comment.java
@@ -28,7 +28,7 @@ public class Comment extends BaseTimeEntity {
     private Comment parent;
 
     @OneToMany(mappedBy = "parent", fetch = FetchType.LAZY, cascade=CascadeType.ALL)
-    private List<Comment> children = new ArrayList<>();
+    private List<Comment> children = new ArrayList<Comment>();
 
     @Column(columnDefinition = "VARCHAR(1000)", nullable=false)
     private String body;
@@ -42,6 +42,10 @@ public class Comment extends BaseTimeEntity {
     private User writer;
 
     private Boolean isDeleted;
+
+    public List<Comment> getChildren() {
+        return children != null ? children : new ArrayList<Comment>();
+    }
 
     public void setAsIsDeleted(){
         isDeleted = Boolean.TRUE;

--- a/src/main/java/com/example/delibuddy/domain/comment/Comment.java
+++ b/src/main/java/com/example/delibuddy/domain/comment/Comment.java
@@ -50,6 +50,7 @@ public class Comment extends BaseTimeEntity {
         return parent != null;
     }
     public void setParent(Comment parent){
+        parent.getChildren().add(this);
         this.parent = parent;
     }
 

--- a/src/main/java/com/example/delibuddy/domain/comment/Comment.java
+++ b/src/main/java/com/example/delibuddy/domain/comment/Comment.java
@@ -12,7 +12,7 @@ import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
 
-@Builder
+
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
@@ -43,8 +43,12 @@ public class Comment extends BaseTimeEntity {
 
     private Boolean isDeleted;
 
-    public List<Comment> getChildren() {
-        return children != null ? children : new ArrayList<Comment>();
+    @Builder
+    public Comment(Comment parent, String body, Party party, User writer){
+        this.parent = parent;
+        this.body = body;
+        this.party = party;
+        this.writer = writer;
     }
 
     public void setAsIsDeleted(){

--- a/src/main/java/com/example/delibuddy/domain/comment/Comment.java
+++ b/src/main/java/com/example/delibuddy/domain/comment/Comment.java
@@ -1,0 +1,49 @@
+package com.example.delibuddy.domain.comment;
+
+import com.example.delibuddy.domain.BaseTimeEntity;
+import com.example.delibuddy.domain.party.Party;
+import com.example.delibuddy.domain.user.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Entity
+public class Comment extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade=CascadeType.ALL)
+    @JoinColumn(name = "parent_id")
+    private Comment parent;
+
+    @OneToMany(mappedBy = "parent", fetch = FetchType.LAZY, cascade=CascadeType.ALL)
+    private List<Comment> children = new ArrayList<>();
+
+    @Column(columnDefinition = "VARCHAR(1000)", nullable=false)
+    private String body;
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade=CascadeType.ALL)
+    @JoinColumn(name = "party_id")
+    private Party party;
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade=CascadeType.ALL)
+    @JoinColumn(name = "user_id")
+    private User writer;
+
+    private Boolean isDeleted;
+
+    public void setAsIsDeleted(){
+        isDeleted = Boolean.TRUE;
+    }
+}

--- a/src/main/java/com/example/delibuddy/domain/comment/CommentRepository.java
+++ b/src/main/java/com/example/delibuddy/domain/comment/CommentRepository.java
@@ -1,0 +1,6 @@
+package com.example.delibuddy.domain.comment;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/com/example/delibuddy/domain/comment/comment.java
+++ b/src/main/java/com/example/delibuddy/domain/comment/comment.java
@@ -1,4 +1,0 @@
-package com.example.delibuddy.domain.comment;
-
-public class comment {
-}

--- a/src/main/java/com/example/delibuddy/service/CommentService.java
+++ b/src/main/java/com/example/delibuddy/service/CommentService.java
@@ -1,0 +1,65 @@
+package com.example.delibuddy.service;
+
+import com.example.delibuddy.domain.comment.Comment;
+import com.example.delibuddy.domain.comment.CommentRepository;
+import com.example.delibuddy.domain.party.Party;
+import com.example.delibuddy.domain.party.PartyRepository;
+import com.example.delibuddy.domain.user.User;
+import com.example.delibuddy.domain.user.UserRepository;
+import com.example.delibuddy.web.dto.CommentCreationRequestDto;
+import com.example.delibuddy.web.dto.CommentResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class CommentService {
+    private final PartyRepository partyRepository;
+    private final CommentRepository commentRepository;
+    private final UserRepository userRepository;
+
+//    @Transactional(readOnly = true)
+//    public List<CommentResponseDto> getCommentsInParty(Long partyId) {
+//        // TODO 댓글은 작성 시간순 정렬, 댓글 아래에 대댓글이 보이게 출력
+//        // TODO 삭제됐지만 자식 댓글이 있는 경우 "삭제된 댓글입니다"로 출력
+//    }
+
+
+    @Transactional
+    public CommentResponseDto create(CommentCreationRequestDto dto, String writerKakaoId) {
+        User writer = userRepository.findByKakaoId(writerKakaoId).get();
+
+        Party party = partyRepository.getById(dto.getPartyId());
+        Comment parent = commentRepository.findById(dto.getParentId()).orElse(null);
+        Comment comment = dto.toEntity(writer, party, parent);
+
+        if (parent != null) { // 부모 댓글이 있는 경우 == 대댓글인 경우
+            if (parent.getParent() != null) { // 부모 댓글의 부모가 있는 경우
+                throw new IllegalArgumentException("대댓글에는 대댓글을 달 수 없습니다.");
+            }
+            else{
+                parent.getChildren().add(comment);
+            }
+        }
+        commentRepository.save(comment);
+        // Party party = partyRepository.getById(dto.getPartyId());
+        // party.getComments().add(comment);
+        return new CommentResponseDto(comment);
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        Comment comment = commentRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("comment 가 없습니다."));
+        if(comment.getChildren().size() != 0) {
+            comment.setAsIsDeleted();
+        } else {
+            commentRepository.delete(comment);
+        }
+    }
+
+
+}

--- a/src/main/java/com/example/delibuddy/service/CommentService.java
+++ b/src/main/java/com/example/delibuddy/service/CommentService.java
@@ -31,18 +31,17 @@ public class CommentService {
     @Transactional
     public CommentResponseDto create(CommentCreationRequestDto dto, String writerKakaoId) {
         User writer = userRepository.findByKakaoId(writerKakaoId).get();
-
         Party party = partyRepository.getById(dto.getPartyId());
-        Comment parent = commentRepository.findById(dto.getParentId()).orElse(null);
-        Comment comment = dto.toEntity(writer, party, parent);
 
-        if (parent != null) { // 부모 댓글이 있는 경우 == 대댓글인 경우
-            if (parent.getParent() != null) { // 부모 댓글의 부모가 있는 경우
+        Comment comment = dto.toEntity(writer, party);
+
+        if (dto.getParentId() != null) {
+            Comment parent = commentRepository.getById(dto.getParentId());
+            if (parent.hasParent()) {
                 throw new IllegalArgumentException("대댓글에는 대댓글을 달 수 없습니다.");
             }
-            else{
-                parent.getChildren().add(comment);
-            }
+            parent.getChildren().add(comment);
+            comment.setParent(parent);
         }
         commentRepository.save(comment);
         // Party party = partyRepository.getById(dto.getPartyId());

--- a/src/main/java/com/example/delibuddy/service/CommentService.java
+++ b/src/main/java/com/example/delibuddy/service/CommentService.java
@@ -40,7 +40,6 @@ public class CommentService {
             if (parent.hasParent()) {
                 throw new IllegalArgumentException("대댓글에는 대댓글을 달 수 없습니다.");
             }
-            parent.getChildren().add(comment);
             comment.setParent(parent);
         }
         commentRepository.save(comment);

--- a/src/main/java/com/example/delibuddy/web/CommentController.java
+++ b/src/main/java/com/example/delibuddy/web/CommentController.java
@@ -1,0 +1,28 @@
+package com.example.delibuddy.web;
+
+import com.example.delibuddy.service.CommentService;
+import com.example.delibuddy.web.auth.MyUserDetails;
+import com.example.delibuddy.web.dto.CommentCreationRequestDto;
+import com.example.delibuddy.web.dto.CommentResponseDto;
+import io.swagger.annotations.Api;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@Api(tags = "Comment")
+@RequiredArgsConstructor
+@RestController
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping("api/v1/comments")
+    // api/v1/party/{partyId}/comments 가 맞을까..?
+    public CommentResponseDto createComment(@RequestBody CommentCreationRequestDto requestDto) {
+        MyUserDetails userDetails = (MyUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        return commentService.create(requestDto, userDetails.getUsername());
+    }
+
+}

--- a/src/main/java/com/example/delibuddy/web/dto/CommentCreationRequestDto.java
+++ b/src/main/java/com/example/delibuddy/web/dto/CommentCreationRequestDto.java
@@ -13,12 +13,11 @@ public class CommentCreationRequestDto {
     private final Long partyId;
     private final Long parentId;
 
-    public Comment toEntity(User writer, Party party, Comment parent) {
+    public Comment toEntity(User writer, Party party) {
         return Comment.builder()
                 .body(body)
                 .party(party)
                 .writer(writer)
-                .parent(parent)
                 .build();
     }
 

--- a/src/main/java/com/example/delibuddy/web/dto/CommentCreationRequestDto.java
+++ b/src/main/java/com/example/delibuddy/web/dto/CommentCreationRequestDto.java
@@ -3,9 +3,12 @@ package com.example.delibuddy.web.dto;
 import com.example.delibuddy.domain.comment.Comment;
 import com.example.delibuddy.domain.party.Party;
 import com.example.delibuddy.domain.user.User;
+import lombok.Builder;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 
+
+@Builder
 @Data
 @RequiredArgsConstructor
 public class CommentCreationRequestDto {

--- a/src/main/java/com/example/delibuddy/web/dto/CommentCreationRequestDto.java
+++ b/src/main/java/com/example/delibuddy/web/dto/CommentCreationRequestDto.java
@@ -1,0 +1,25 @@
+package com.example.delibuddy.web.dto;
+
+import com.example.delibuddy.domain.comment.Comment;
+import com.example.delibuddy.domain.party.Party;
+import com.example.delibuddy.domain.user.User;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+@Data
+@RequiredArgsConstructor
+public class CommentCreationRequestDto {
+    private final String body;
+    private final Long partyId;
+    private final Long parentId;
+
+    public Comment toEntity(User writer, Party party, Comment parent) {
+        return Comment.builder()
+                .body(body)
+                .party(party)
+                .writer(writer)
+                .parent(parent)
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/delibuddy/web/dto/CommentResponseDto.java
+++ b/src/main/java/com/example/delibuddy/web/dto/CommentResponseDto.java
@@ -1,0 +1,29 @@
+package com.example.delibuddy.web.dto;
+
+import com.example.delibuddy.domain.comment.Comment;
+import com.example.delibuddy.domain.party.Party;
+import com.example.delibuddy.domain.user.User;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@Data
+@RequiredArgsConstructor
+public class CommentResponseDto {
+    private Long id;
+    private Comment parent;
+    private List<Comment> children;
+    private String body;
+    private Party party;
+    private User writer;
+
+    public CommentResponseDto(Comment entity) {
+        id = entity.getId();
+        parent = entity.getParent();
+        children = entity.getChildren();
+        body = entity.getBody();
+        party = entity.getParty();
+        writer = entity.getWriter();
+    }
+}

--- a/src/main/java/com/example/delibuddy/web/dto/CommentResponseDto.java
+++ b/src/main/java/com/example/delibuddy/web/dto/CommentResponseDto.java
@@ -7,13 +7,14 @@ import lombok.Data;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Data
 @RequiredArgsConstructor
 public class CommentResponseDto {
     private Long id;
     private Comment parent;
-    private List<Comment> children;
+    private List<CommentResponseDto> children;
     private String body;
     private Party party;
     private User writer;
@@ -21,7 +22,7 @@ public class CommentResponseDto {
     public CommentResponseDto(Comment entity) {
         id = entity.getId();
         parent = entity.getParent();
-        children = entity.getChildren();
+        children = entity.getChildren().stream().map(child -> new CommentResponseDto(child)).collect(Collectors.toList());
         body = entity.getBody();
         party = entity.getParty();
         writer = entity.getWriter();

--- a/src/main/java/com/example/delibuddy/web/dto/CommentResponseDto.java
+++ b/src/main/java/com/example/delibuddy/web/dto/CommentResponseDto.java
@@ -4,6 +4,7 @@ import com.example.delibuddy.domain.comment.Comment;
 import com.example.delibuddy.domain.party.Party;
 import com.example.delibuddy.domain.user.User;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
@@ -12,12 +13,12 @@ import java.util.stream.Collectors;
 @Data
 @RequiredArgsConstructor
 public class CommentResponseDto {
-    private Long id;
-    private Comment parent;
-    private List<CommentResponseDto> children;
-    private String body;
-    private Party party;
-    private User writer;
+    private final Long id;
+    private final Comment parent;
+    private final List<CommentResponseDto> children;
+    private final String body;
+    private final Party party;
+    private final User writer;
 
     public CommentResponseDto(Comment entity) {
         id = entity.getId();

--- a/src/test/java/com/example/delibuddy/domain/comment/CommentRepositoryTest.java
+++ b/src/test/java/com/example/delibuddy/domain/comment/CommentRepositoryTest.java
@@ -1,0 +1,52 @@
+package com.example.delibuddy.domain.comment;
+
+import com.example.delibuddy.domain.party.Party;
+import com.example.delibuddy.domain.user.User;
+import org.aspectj.lang.annotation.After;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.text.ParseException;
+import java.util.List;
+
+@SpringBootTest
+@Transactional
+public class CommentRepositoryTest {
+
+    @Autowired
+    CommentRepository commentRepository;
+
+//    @After
+//    public void cleanup(){
+//        commentRepository.deleteAll();
+//    }
+
+    @Test
+    public void 댓글_등록() throws ParseException {
+        // Given
+        String body = "테스트 댓글";
+        Party party = Party.builder().title("테스트 파티 제목")
+                .body("테스트 파티 내용").build();
+        User writer = User.builder().kakaoId("테스트 카카오 아이디").build();
+
+        commentRepository.save(Comment.builder()
+                .body(body)
+                .party(party)
+                .writer(writer)
+                .build());
+        // When
+        List<Comment> commentList = commentRepository.findAll();
+
+        // Then
+        Comment comment = commentList.get(0);
+        assertEquals(comment.getBody(), body);
+        assertEquals(comment.getParty(), party);
+        assertEquals(comment.getWriter(), writer);
+
+
+;    }
+
+}

--- a/src/test/java/com/example/delibuddy/service/comment/CommentServiceTest.java
+++ b/src/test/java/com/example/delibuddy/service/comment/CommentServiceTest.java
@@ -1,11 +1,27 @@
 package com.example.delibuddy.service.comment;
 
+import com.example.delibuddy.domain.comment.Comment;
 import com.example.delibuddy.domain.comment.CommentRepository;
+import com.example.delibuddy.domain.party.Party;
+import com.example.delibuddy.domain.party.PartyRepository;
+import com.example.delibuddy.domain.user.User;
+import com.example.delibuddy.domain.user.UserRepository;
 import com.example.delibuddy.service.CommentService;
+import com.example.delibuddy.web.dto.CommentCreationRequestDto;
+import com.example.delibuddy.web.dto.CommentResponseDto;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.orm.jpa.JpaObjectRetrievalFailureException;
 import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityNotFoundException;
+import java.util.List;
+
+import static com.sun.tools.doclets.formats.html.markup.HtmlStyle.title;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest
 @Transactional
@@ -14,23 +30,172 @@ public class CommentServiceTest {
     private CommentRepository commentRepository;
 
     @Autowired
+    private PartyRepository partyRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
     private CommentService commentService;
 
     @Test
     void 댓글을_등록할_수_있다(){
+        //given : 파티와 유저와 댓글 달 내용
+        Party party = partyRepository.save(Party.builder().build());
+        User writer = userRepository.save(
+                User.builder()
+                        .nickName("test")
+                        .kakaoId("test-kakao-id")
+                        .build()
+        );
+
+        String body = "테스트 댓글";
+        CommentCreationRequestDto dto = CommentCreationRequestDto.builder()
+                .body(body)
+                .partyId(party.getId())
+                .build();
+
+        //when : 댓글을 생성한다.
+        CommentResponseDto response = commentService.create(dto, writer.getKakaoId());
+
+
+        //then : 댓글이 뾰로롱~ 생성이 된다.
+        Comment comment = commentRepository.getById(response.getId());
+        assertThat(comment.getBody()).isEqualTo(body);
+        assertThat(comment.getParty()).isEqualTo(party);
+        assertThat(comment.getWriter()).isEqualTo(writer);
+    }
+
+    @Test
+    void 대댓글을_등록할_수_있다(){
+        //given : 파티, 유저, 부모 댓글과 댓글 달 내용
+        Party party = partyRepository.save(Party.builder().build());
+        User writer = userRepository.save(
+                User.builder()
+                        .nickName("test")
+                        .kakaoId("test-kakao-id")
+                        .build()
+        );
+        Comment parent = commentRepository.save(Comment.builder()
+                        .body("테스트 부모 댓글")
+                        .party(party)
+                        .writer(writer)
+                        .build());
+
+        String body = "테스트 대댓글";
+        CommentCreationRequestDto dto = CommentCreationRequestDto.builder()
+                .body(body)
+                .partyId(party.getId())
+                .parentId(parent.getId())
+                .build();
+
+        //when : 대댓글을 생성한다.
+        CommentResponseDto response = commentService.create(dto, writer.getKakaoId());
+
+
+        //then : 대댓글이 뾰로롱~ 생성이 된다.
+        Comment comment = commentRepository.getById(response.getId());
+        assertThat(comment.getBody()).isEqualTo(body);
+        assertThat(comment.getParty()).isEqualTo(party);
+        assertThat(comment.getParent()).isEqualTo(parent);
+        assertThat(comment.getWriter()).isEqualTo(writer);
+        // assertThat(comment).isIn(parent.getChildren()); TODO 이거 왜 빈 리스트로 뜨지..?
     }
 
     @Test
     void 대댓글의_대댓글을_등록할_수_없다(){
+        //given : 파티, 유저, 부모 댓글과 자식 댓글, 댓글 달 내용
+        Party party = partyRepository.save(Party.builder().build());
+        User writer = userRepository.save(
+                User.builder()
+                        .nickName("test")
+                        .kakaoId("test-kakao-id")
+                        .build()
+        );
+        Comment parent = commentRepository.save(Comment.builder()
+                        .body("테스트 부모 댓글")
+                        .party(party)
+                        .writer(writer)
+                        .build());
+
+        Comment child = commentRepository.save(Comment.builder()
+                        .body("테스트 자식댓글")
+                        .party(party)
+                        .parent(parent)
+                        .writer(writer)
+                        .build());
+
+        String body = "테스트 자식댓글의 대댓글";
+        CommentCreationRequestDto dto = CommentCreationRequestDto.builder()
+                .body(body)
+                .partyId(party.getId())
+                .parentId(child.getId())
+                .build();
+
+        //expect : 자식댓글의 대댓글을 등록한다. 예외터짐
+        IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class, () -> commentService.create(dto, writer.getKakaoId()));
+        System.out.println("illegalArgumentException = " + illegalArgumentException);
     }
 
     @Test
     void 댓글을_조회하면_자식들도_조회된다(){}
 
     @Test
-    void 자식_댓글이_없는_경우에는_댓글이_삭제된다(){}
+    void 자식_댓글이_없는_경우에는_댓글이_삭제된다(){
+        //given : 파티와 유저와 댓글
+        Party party = partyRepository.save(Party.builder().build());
+        User writer = userRepository.save(
+                User.builder()
+                        .nickName("test")
+                        .kakaoId("test-kakao-id")
+                        .build()
+        );
+
+        Comment comment = commentRepository.save(Comment.builder()
+                .body("테스트 댓글")
+                .party(party)
+                .writer(writer)
+                .build());
+
+        //when : 댓글을 삭제한다.
+        commentService.delete(comment.getId());
+
+
+        //then : 댓글이 뾰로롱~ 삭제 된다. 댓글을 불러오려고 하면 예외 터짐
+        assertThrows(JpaObjectRetrievalFailureException.class, () -> commentRepository.getById(comment.getId()));
+
+
+    }
 
     @Test
-    void 자식_댓글이_있는_경우에는_댓글_내용이_사라진다(){}
+    void 자식_댓글이_있는_경우에는_댓글_내용이_사라진다(){
+        Party party = partyRepository.save(Party.builder().build());
+        User writer = userRepository.save(
+                User.builder()
+                        .nickName("test")
+                        .kakaoId("test-kakao-id")
+                        .build()
+        );
+        Comment parent = commentRepository.save(Comment.builder()
+                .body("테스트 부모 댓글")
+                .party(party)
+                .writer(writer)
+                .build());
+
+        Comment child = commentRepository.save(Comment.builder()
+                .body("테스트 자식댓글")
+                .party(party)
+                .parent(parent)
+                .writer(writer)
+                .build());
+
+        //when : 댓글을 삭제한다.
+        commentService.delete(parent.getId());
+
+
+        //then : 댓글 삭제는 안되고, isDeleted 만 참으로 설정됨
+        Comment comment = commentRepository.getById(parent.getId());
+        assertTrue(comment.getIsDeleted());
+    }
 
 }

--- a/src/test/java/com/example/delibuddy/service/comment/CommentServiceTest.java
+++ b/src/test/java/com/example/delibuddy/service/comment/CommentServiceTest.java
@@ -1,0 +1,36 @@
+package com.example.delibuddy.service.comment;
+
+import com.example.delibuddy.domain.comment.CommentRepository;
+import com.example.delibuddy.service.CommentService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+public class CommentServiceTest {
+    @Autowired
+    private CommentRepository commentRepository;
+
+    @Autowired
+    private CommentService commentService;
+
+    @Test
+    void 댓글을_등록할_수_있다(){
+    }
+
+    @Test
+    void 대댓글의_대댓글을_등록할_수_없다(){
+    }
+
+    @Test
+    void 댓글을_조회하면_자식들도_조회된다(){}
+
+    @Test
+    void 자식_댓글이_없는_경우에는_댓글이_삭제된다(){}
+
+    @Test
+    void 자식_댓글이_있는_경우에는_댓글_내용이_사라진다(){}
+
+}

--- a/src/test/java/com/example/delibuddy/service/comment/CommentServiceTest.java
+++ b/src/test/java/com/example/delibuddy/service/comment/CommentServiceTest.java
@@ -15,10 +15,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.orm.jpa.JpaObjectRetrievalFailureException;
 import org.springframework.transaction.annotation.Transactional;
 
-import javax.persistence.EntityNotFoundException;
-import java.util.List;
-
-import static com.sun.tools.doclets.formats.html.markup.HtmlStyle.title;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -99,7 +95,7 @@ public class CommentServiceTest {
         assertThat(comment.getParty()).isEqualTo(party);
         assertThat(comment.getParent()).isEqualTo(parent);
         assertThat(comment.getWriter()).isEqualTo(writer);
-        // assertThat(comment).isIn(parent.getChildren()); TODO 이거 왜 빈 리스트로 뜨지..?
+        assertThat(comment).isIn(parent.getChildren());
     }
 
     @Test
@@ -134,7 +130,6 @@ public class CommentServiceTest {
 
         //expect : 자식댓글의 대댓글을 등록한다. 예외터짐
         IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class, () -> commentService.create(dto, writer.getKakaoId()));
-        System.out.println("illegalArgumentException = " + illegalArgumentException);
     }
 
     @Test
@@ -169,6 +164,7 @@ public class CommentServiceTest {
 
     @Test
     void 자식_댓글이_있는_경우에는_댓글_내용이_사라진다(){
+        //given : 파티,유저, 부모 댓글과 자식 댓글
         Party party = partyRepository.save(Party.builder().build());
         User writer = userRepository.save(
                 User.builder()
@@ -185,13 +181,13 @@ public class CommentServiceTest {
         Comment child = commentRepository.save(Comment.builder()
                 .body("테스트 자식댓글")
                 .party(party)
-                .parent(parent)
                 .writer(writer)
                 .build());
 
-        //when : 댓글을 삭제한다.
-        commentService.delete(parent.getId());
+        child.setParent(parent);
 
+        //when : 부모 댓글을 삭제한다.
+        commentService.delete(parent.getId());
 
         //then : 댓글 삭제는 안되고, isDeleted 만 참으로 설정됨
         Comment comment = commentRepository.getById(parent.getId());


### PR DESCRIPTION
### 작업 내용
* 댓글 엔티티를 만들었습니다.
* 댓글 Service의 create, delete를 만들었습니다.
* 댓글 create controller를 만들었습니다.
* 댓글 repository test를 만들었습니다.

### 기타사항
* 추가 구현이 필요한 비즈니스 로직은 / 테스트 케이스는 TODO로 명시해놨습니다.
* 추가로 Party Entity에 comments 필드를 추가해야합니다.
```java
@OneToMany(mappedBy = "party", fetch = FetchType.LAZY)
private List<Comment> comments = new ArrayList<>();
```
* Party 상세 조회 시, `CommentService.getCommentsInParty`를 호출해서 댓글을 같이 반환해주는 로직을 추가해야 합니다.