### PR TITLE
Hj comment api 2

### DIFF
--- a/src/main/java/com/example/delibuddy/domain/comment/Comment.java
+++ b/src/main/java/com/example/delibuddy/domain/comment/Comment.java
@@ -23,21 +23,21 @@ public class Comment extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade=CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_id")
     private Comment parent;
 
-    @OneToMany(mappedBy = "parent", fetch = FetchType.LAZY, cascade=CascadeType.ALL)
+    @OneToMany(mappedBy = "parent", fetch = FetchType.LAZY)
     private List<Comment> children = new ArrayList<Comment>();
 
     @Column(columnDefinition = "VARCHAR(1000)", nullable=false)
     private String body;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade=CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "party_id")
     private Party party;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade=CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User writer;
 

--- a/src/main/java/com/example/delibuddy/domain/comment/Comment.java
+++ b/src/main/java/com/example/delibuddy/domain/comment/Comment.java
@@ -41,7 +41,7 @@ public class Comment extends BaseTimeEntity {
     @JoinColumn(name = "user_id")
     private User writer;
 
-    private Boolean isDeleted;
+    private Boolean isDeleted = Boolean.FALSE;
 
     @Builder
     public Comment(Comment parent, String body, Party party, User writer){

--- a/src/main/java/com/example/delibuddy/domain/comment/CommentRepository.java
+++ b/src/main/java/com/example/delibuddy/domain/comment/CommentRepository.java
@@ -1,6 +1,13 @@
 package com.example.delibuddy.domain.comment;
 
+import com.example.delibuddy.domain.party.Party;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+    @Query
+    List<Comment> findByPartyAndParentIsNull(Party party, Sort sort);
 }

--- a/src/main/java/com/example/delibuddy/web/CommentController.java
+++ b/src/main/java/com/example/delibuddy/web/CommentController.java
@@ -4,12 +4,13 @@ import com.example.delibuddy.service.CommentService;
 import com.example.delibuddy.web.auth.MyUserDetails;
 import com.example.delibuddy.web.dto.CommentCreationRequestDto;
 import com.example.delibuddy.web.dto.CommentResponseDto;
+import com.example.delibuddy.web.dto.OkayDto;
 import io.swagger.annotations.Api;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Api(tags = "Comment")
 @RequiredArgsConstructor
@@ -18,11 +19,22 @@ public class CommentController {
 
     private final CommentService commentService;
 
-    @PostMapping("api/v1/comments")
-    // api/v1/party/{partyId}/comments 가 맞을까..?
+    @PostMapping("${api.v1}/comments")
     public CommentResponseDto createComment(@RequestBody CommentCreationRequestDto requestDto) {
         MyUserDetails userDetails = (MyUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         return commentService.create(requestDto, userDetails.getUsername());
+    }
+
+    @GetMapping("${api.v1}/parties/{id}/comments")
+    public List<CommentResponseDto> getCommentsInParty(@PathVariable Long id) {
+        return commentService.getCommentsInParty(id);
+    }
+
+    @DeleteMapping("${api.v1}/comments/{id}")
+    public OkayDto deleteComment(@PathVariable Long id) {
+        MyUserDetails userDetails = (MyUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        commentService.delete(id, userDetails.getUsername());
+        return new OkayDto();
     }
 
 }

--- a/src/main/java/com/example/delibuddy/web/PartyController.java
+++ b/src/main/java/com/example/delibuddy/web/PartyController.java
@@ -66,7 +66,7 @@ public class PartyController {
     }
 
     @GetMapping("${api.v1}/parties/{id}") // url parameter
-    public PartyResponseDto getParty(@RequestParam Long id) {
+    public PartyResponseDto getParty(@PathVariable Long id) {
         return partyService.getParty(id);
     }
 

--- a/src/main/java/com/example/delibuddy/web/dto/CommentCreationRequestDto.java
+++ b/src/main/java/com/example/delibuddy/web/dto/CommentCreationRequestDto.java
@@ -3,18 +3,15 @@ package com.example.delibuddy.web.dto;
 import com.example.delibuddy.domain.comment.Comment;
 import com.example.delibuddy.domain.party.Party;
 import com.example.delibuddy.domain.user.User;
-import lombok.Builder;
 import lombok.Data;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 
-
-@Builder
 @Data
-@RequiredArgsConstructor
+@NoArgsConstructor
 public class CommentCreationRequestDto {
-    private final String body;
-    private final Long partyId;
-    private final Long parentId;
+    private String body;
+    private Long partyId;
+    private Long parentId;
 
     public Comment toEntity(User writer, Party party) {
         return Comment.builder()

--- a/src/main/java/com/example/delibuddy/web/dto/CommentCreationRequestDto.java
+++ b/src/main/java/com/example/delibuddy/web/dto/CommentCreationRequestDto.java
@@ -3,6 +3,7 @@ package com.example.delibuddy.web.dto;
 import com.example.delibuddy.domain.comment.Comment;
 import com.example.delibuddy.domain.party.Party;
 import com.example.delibuddy.domain.user.User;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -12,6 +13,13 @@ public class CommentCreationRequestDto {
     private String body;
     private Long partyId;
     private Long parentId;
+
+    @Builder
+    public CommentCreationRequestDto(String body, Long partyId, Long parentId) {
+        this.body = body;
+        this.partyId = partyId;
+        this.parentId = parentId;
+    }
 
     public Comment toEntity(User writer, Party party) {
         return Comment.builder()

--- a/src/main/java/com/example/delibuddy/web/dto/CommentResponseDto.java
+++ b/src/main/java/com/example/delibuddy/web/dto/CommentResponseDto.java
@@ -6,7 +6,9 @@ import com.example.delibuddy.domain.user.User;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -14,18 +16,20 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class CommentResponseDto {
     private final Long id;
-    private final Comment parent;
+    private final Long parentId;
     private final List<CommentResponseDto> children;
     private final String body;
-    private final Party party;
-    private final User writer;
+    private final Long partyId;
+    private final CommentUserResponseDto writer;
+    private final LocalDateTime createdAt;
 
     public CommentResponseDto(Comment entity) {
         id = entity.getId();
-        parent = entity.getParent();
-        children = entity.getChildren().stream().map(child -> new CommentResponseDto(child)).collect(Collectors.toList());
-        body = entity.getBody();
-        party = entity.getParty();
-        writer = entity.getWriter();
+        parentId = entity.getParent() == null ? null : entity.getParent().getId();
+        children = entity.getChildren().stream().map(CommentResponseDto::new).collect(Collectors.toList());
+        body = entity.getIsDeleted()? new String("삭제된 댓글입니다.") : entity.getBody();
+        partyId = entity.getParty().getId();
+        writer = entity.getIsDeleted()? null : new CommentUserResponseDto(entity.getWriter());
+        createdAt = entity.getCreatedAt();
     }
 }

--- a/src/main/java/com/example/delibuddy/web/dto/CommentUserResponseDto.java
+++ b/src/main/java/com/example/delibuddy/web/dto/CommentUserResponseDto.java
@@ -1,0 +1,20 @@
+package com.example.delibuddy.web.dto;
+
+import com.example.delibuddy.domain.comment.Comment;
+import com.example.delibuddy.domain.user.User;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+import java.util.stream.Collectors;
+
+@Data
+@RequiredArgsConstructor
+public class CommentUserResponseDto {
+    private final String nickName;
+    private final String profileImage;
+
+    public CommentUserResponseDto(User entity) {
+        nickName = entity.getNickName();
+        profileImage = entity.getProfileImage();
+    }
+}

--- a/src/main/java/com/example/delibuddy/web/dto/PartyBanRequestDto.java
+++ b/src/main/java/com/example/delibuddy/web/dto/PartyBanRequestDto.java
@@ -1,15 +1,11 @@
 package com.example.delibuddy.web.dto;
 
 import lombok.Data;
-import lombok.RequiredArgsConstructor;
-import org.locationtech.jts.geom.Point;
-import org.locationtech.jts.io.ParseException;
-
-import static com.example.delibuddy.util.GeoHelper.wktToGeometry;
+import lombok.NoArgsConstructor;
 
 
 @Data
-@RequiredArgsConstructor
+@NoArgsConstructor
 public class PartyBanRequestDto {
-    private final Long targetId;
+    private Long targetId;
 }

--- a/src/main/java/com/example/delibuddy/web/dto/PartyChangeStatusRequestDto.java
+++ b/src/main/java/com/example/delibuddy/web/dto/PartyChangeStatusRequestDto.java
@@ -2,18 +2,14 @@ package com.example.delibuddy.web.dto;
 
 import com.example.delibuddy.domain.party.PartyStatus;
 import lombok.Data;
-import lombok.RequiredArgsConstructor;
-import org.locationtech.jts.geom.Point;
-import org.locationtech.jts.io.ParseException;
-
-import static com.example.delibuddy.util.GeoHelper.wktToGeometry;
+import lombok.NoArgsConstructor;
 
 
 @Data
-@RequiredArgsConstructor
+@NoArgsConstructor
 public class PartyChangeStatusRequestDto {
 
-    private final String status;
+    private String status;
 
     public PartyStatus getPartyStatus() {
         // todo: PartyStatus 를 찾아서 리턴하자.

--- a/src/main/java/com/example/delibuddy/web/dto/PartyCreationRequestDto.java
+++ b/src/main/java/com/example/delibuddy/web/dto/PartyCreationRequestDto.java
@@ -2,19 +2,27 @@ package com.example.delibuddy.web.dto;
 
 import com.example.delibuddy.domain.party.Party;
 import com.example.delibuddy.domain.user.User;
+import lombok.Builder;
 import lombok.Data;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.io.ParseException;
 
 import static com.example.delibuddy.util.GeoHelper.wktToGeometry;
 
 @Data
-@RequiredArgsConstructor
+@NoArgsConstructor
 public class PartyCreationRequestDto {
-    private final String title;
-    private final String body;
-    private final String coordinate;
+    private String title;
+    private String body;
+    private String coordinate;
+
+    @Builder
+    public PartyCreationRequestDto(String title, String body, String coordinate) {
+        this.title = title;
+        this.body = body;
+        this.coordinate = coordinate;
+    }
 
     public Party toEntity(User leader) {
         Point point;

--- a/src/main/java/com/example/delibuddy/web/dto/PartyEditRequestDto.java
+++ b/src/main/java/com/example/delibuddy/web/dto/PartyEditRequestDto.java
@@ -1,7 +1,7 @@
 package com.example.delibuddy.web.dto;
 
 import lombok.Data;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.io.ParseException;
 
@@ -9,14 +9,14 @@ import static com.example.delibuddy.util.GeoHelper.wktToGeometry;
 
 
 @Data
-@RequiredArgsConstructor
+@NoArgsConstructor
 public class PartyEditRequestDto {
     // serializer 처럼 필드가 자동생성되면 얼마나 좋을까 ㅎㅎ
     // TODO: serializer 가 어떻게 필드를 자동생성하는지 알아보자.
 
-    private final String title;
-    private final String body;
-    private final String coordinate;
+    private String title;
+    private String body;
+    private String coordinate;
 
     public Point getPoint() {
         try {

--- a/src/main/java/com/example/delibuddy/web/dto/PartyEditRequestDto.java
+++ b/src/main/java/com/example/delibuddy/web/dto/PartyEditRequestDto.java
@@ -1,5 +1,6 @@
 package com.example.delibuddy.web.dto;
 
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.locationtech.jts.geom.Point;
@@ -17,6 +18,13 @@ public class PartyEditRequestDto {
     private String title;
     private String body;
     private String coordinate;
+
+    @Builder
+    public PartyEditRequestDto(String title, String body, String coordinate) {
+        this.title = title;
+        this.body = body;
+        this.coordinate = coordinate;
+    }
 
     public Point getPoint() {
         try {

--- a/src/test/java/com/example/delibuddy/domain/comment/CommentRepositoryTest.java
+++ b/src/test/java/com/example/delibuddy/domain/comment/CommentRepositoryTest.java
@@ -1,7 +1,9 @@
 package com.example.delibuddy.domain.comment;
 
 import com.example.delibuddy.domain.party.Party;
+import com.example.delibuddy.domain.party.PartyRepository;
 import com.example.delibuddy.domain.user.User;
+import com.example.delibuddy.domain.user.UserRepository;
 import org.aspectj.lang.annotation.After;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,6 +19,12 @@ import java.util.List;
 public class CommentRepositoryTest {
 
     @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    PartyRepository partyRepository;
+
+    @Autowired
     CommentRepository commentRepository;
 
 //    @After
@@ -28,23 +36,22 @@ public class CommentRepositoryTest {
     public void 댓글_등록() throws ParseException {
         // Given
         String body = "테스트 댓글";
-        Party party = Party.builder().title("테스트 파티 제목")
-                .body("테스트 파티 내용").build();
-        User writer = User.builder().kakaoId("테스트 카카오 아이디").build();
+        Party party = partyRepository.save(Party.builder().title("테스트 파티 제목")
+                .body("테스트 파티 내용").build());
+        User writer = userRepository.save(User.builder().kakaoId("테스트 카카오 아이디").build());
 
-        commentRepository.save(Comment.builder()
+        // When
+        Comment comment = commentRepository.save(Comment.builder()
                 .body(body)
                 .party(party)
                 .writer(writer)
                 .build());
-        // When
-        List<Comment> commentList = commentRepository.findAll();
 
         // Then
-        Comment comment = commentList.get(0);
-        assertEquals(comment.getBody(), body);
-        assertEquals(comment.getParty(), party);
-        assertEquals(comment.getWriter(), writer);
+        Comment resultComment = commentRepository.getById(comment.getId());
+        assertEquals(resultComment.getBody(), body);
+        assertEquals(resultComment.getParty(), party);
+        assertEquals(resultComment.getWriter(), writer);
 
 
 ;    }

--- a/src/test/java/com/example/delibuddy/service/comment/CommentServiceTest.java
+++ b/src/test/java/com/example/delibuddy/service/comment/CommentServiceTest.java
@@ -153,7 +153,7 @@ public class CommentServiceTest {
                 .build());
 
         //when : 댓글을 삭제한다.
-        commentService.delete(comment.getId());
+        commentService.delete(comment.getId(), writer.getKakaoId());
 
 
         //then : 댓글이 뾰로롱~ 삭제 된다. 댓글을 불러오려고 하면 예외 터짐
@@ -187,7 +187,7 @@ public class CommentServiceTest {
         child.setParent(parent);
 
         //when : 부모 댓글을 삭제한다.
-        commentService.delete(parent.getId());
+        commentService.delete(parent.getId(), writer.getKakaoId());
 
         //then : 댓글 삭제는 안되고, isDeleted 만 참으로 설정됨
         Comment comment = commentRepository.getById(parent.getId());

--- a/src/test/java/com/example/delibuddy/web/CommentControllerTest.java
+++ b/src/test/java/com/example/delibuddy/web/CommentControllerTest.java
@@ -1,0 +1,112 @@
+package com.example.delibuddy.web;
+
+import com.example.delibuddy.domain.comment.Comment;
+import com.example.delibuddy.domain.comment.CommentRepository;
+import com.example.delibuddy.domain.party.Party;
+import com.example.delibuddy.domain.party.PartyRepository;
+import com.example.delibuddy.domain.user.User;
+import com.example.delibuddy.domain.user.UserRepository;
+import com.example.delibuddy.service.MyUserDetailsService;
+import com.example.delibuddy.web.dto.CommentCreationRequestDto;
+import com.example.delibuddy.web.dto.CommentResponseDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+@SpringBootTest
+@Transactional
+public class CommentControllerTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private MyUserDetailsService userDetailsService;
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @Autowired
+    private PartyRepository partyRepository;
+
+    @Autowired
+    private CommentRepository commentRepository;
+
+    private User user;
+
+    private MockMvc mvc;
+
+
+    @BeforeEach
+    void setUp() {
+        user = userRepository.save(
+                User.builder()
+                        .nickName("test")
+                        .kakaoId("test-kakao-id")
+                        .build()
+        );
+
+        UserDetails userDetails = userDetailsService.loadUserByUsername(user.getKakaoId());
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(userDetails, "", new ArrayList<>())
+        );
+
+        mvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .apply(springSecurity())
+                .build();
+    }
+    @Test
+    public void 댓글이_등록된다() throws Exception {
+
+        //given : 파티와 유저와 댓글 달 내용
+        Party party = partyRepository.save(Party.builder().build());
+
+        String body = "테스트 댓글";
+        CommentCreationRequestDto requestDto = CommentCreationRequestDto.builder()
+                .body(body)
+                .partyId(party.getId())
+                .build();
+
+        String url = "http://localhost:8080/api/v1/comments";
+
+        //when : POST 요청 보냄
+        final ResultActions actions = mvc.perform(post(url)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(requestDto)));
+
+
+
+        //then : 생성된 댓글이 리스폰스로 옴
+//        actions
+//                .andExpect(status().isOk())
+//                .andExpect(jsonPath("body").value(body))
+//                .andExpect(jsonPath("party").value(party))
+//                .andExpect(jsonPath("writer").value(user));
+
+        List<Comment> all = commentRepository.findAll();
+        assertThat(all.get(0).getBody()).isEqualTo(body);
+        assertThat(all.get(0).getParty()).isEqualTo(party);
+        assertThat(all.get(0).getWriter()).isEqualTo(user);
+    }
+}


### PR DESCRIPTION
### 작업 내용
* 댓글 Controller 를 작성했습니다.
* 삭제된 부모 댓글은 `body = "삭제된 댓글입니다.", writer=null` 로 리턴하도록 했습니다.  
* 파티별로 댓글을 가져올 수 있는 API 를 작성했습니다
-> 부모 댓글만 가져옴. but 부모 댓글 안에 자식 댓글이 있음
* 댓글 Get Response Dto 형식을 변경했습니다.
-> parentId, partyId, writer(nickname, profile)
```
{
        "id": 5,
        "parentId": null,
        "children": [
            {
                "id": 7,
                "parentId": 5,
                "children": [],
                "body": "댓글",
                "partyId": 2,
                "writer": {
                    "nickName": "임해진",
                    "profileImage": "http://k.kakaocdn.net/dn/yovqY/btqO7iLOfvs/FXMW79M7dtWkLWpYCQhQlK/img_640x640.jpg"
                },
                "createdAt": "2021-11-22T23:02:37"
            }
        ],
        "body": "삭제된 댓글입니다.",
        "partyId": 2,
        "writer": null,
        "createdAt": "2021-11-22T22:53:39"
    }
```

* 모든 API 호출로 테스트 완료한 상태이고, ControllerTest 작성만 남은 상태입니다. (미리 PR 올리는 거고, ControllerTest 도 빠르게 작성해서 올릴게요!)

### 기타사항
* `hj-fix-request-dto` 브랜치에 의존하는 PR 입니다
* 해당 [PR](https://github.com/YAPP-19th/Android-Team-1-Backend/pull/15) merge 후에 merge하도록 하겠습니다.